### PR TITLE
Update model.py

### DIFF
--- a/svi_percept/model.py
+++ b/svi_percept/model.py
@@ -76,5 +76,5 @@ class SVIPerceptModel(PreTrainedModel):
             kweights = torch.pow(10.0, raw_weights)  # [batch_size, self.k]
             kweights = torch.nn.functional.softmax(kweights, dim=1)  # [batch_size, self.k]
             kscores = scores[indices]  # [batch_size, self.k]
-            results[:, cat_i] = torch.sum(kscores * kweights, dim=1)
+            results[:, cat_i] = torch.sum(kscores * kweights, dim=1).cpu()
         return {"results": results}


### PR DESCRIPTION
When using GPU acceleration, we need to modify SVIPerceptPipeline(batch_size=32) in the example.py to SVIPerceptPipeline(batch_size=32, device="cuda"). Also, in the model.py, change results[:, cat_i] = torch.sum(kscores * kweights, dim=1) to results[:, cat_i] = torch.sum(kscores * kweights, dim=1).cpu().